### PR TITLE
Added feature to allow VMG Chosen Member field to replace EE author dropdown

### DIFF
--- a/ee2/third_party/vmg_chosen_member/ft.vmg_chosen_member.php
+++ b/ee2/third_party/vmg_chosen_member/ft.vmg_chosen_member.php
@@ -70,7 +70,6 @@ class Vmg_chosen_member_ft extends EE_Fieldtype
 			'col_id' => (isset($this->col_id) ? $this->col_id : 0),
 			'max_selections' => $this->settings['max_selections'],
 			'placeholder_text' => $this->settings['placeholder_text'],
-			'auto_update_author' => $this->settings['auto_update_author'],
 			'is_matrix' => (isset($this->cell_name) ? true : false),
 			'is_low_var' => (isset($this->var_id) ? true : false),
 		);
@@ -293,7 +292,7 @@ class Vmg_chosen_member_ft extends EE_Fieldtype
 				form_multiselect('search_fields[]', $search_fields, (!empty($data['search_fields']) ? $data['search_fields'] : array()))
 			),
 			array(
-				'<strong>Auto-update author dropdown</strong><br/>Check if you want this field to auto-update the author dropdown. N.B. The author dropdown must be present on the channel entry page.', 
+				'<strong>Auto-update author dropdown</strong><br/>Check if you want this field to override the entry author. If multiple members are selected, the author will default to the first in the list.', 
 				form_checkbox('auto_update_author', '1', (!empty($data['auto_update_author']) ? $data['auto_update_author'] : 0))
 			),
 		);
@@ -390,6 +389,28 @@ class Vmg_chosen_member_ft extends EE_Fieldtype
 		
     	return $result_data;
     }
+    
+    
+    /**
+     * Post Save Field
+     */
+    function post_save($field_data)
+    {
+    	// if this field was set to act as author override...
+    	if ($this->settings['auto_update_author']) {
+    		$members = explode('|', $field_data);
+    		
+    		$this->EE->db->set('author_id', $members[0]); 	// 	Always set author_id to the first member, if multiple were selected.
+    														//	Just stops unexpected fieldtype behaviour.
+    														
+    		$this->EE->db->where('entry_id', $this->settings['entry_id']);
+    		$this->EE->db->update('channel_titles');	
+    	}
+    	
+		return $field_data;
+    }
+
+    
     
     
     /**

--- a/ee2/third_party/vmg_chosen_member/views/display_field.php
+++ b/ee2/third_party/vmg_chosen_member/views/display_field.php
@@ -7,6 +7,5 @@
 	<input type="hidden" id="vmg_chosen_member_<?=$unique?>_field_id" value="<?=$field_id?>"/>
 	<input type="hidden" id="vmg_chosen_member_<?=$unique?>_max_selections" value="<?=$max_selections?>"/>
 	<input type="hidden" id="vmg_chosen_member_<?=$unique?>_placeholder_text" value="<?=$placeholder_text?>"/>
-	<input type="hidden" id="vmg_chosen_member_<?=$unique?>_auto_update_author" value="<?=$auto_update_author?>"/>
 	<input type="hidden" class="vmg_chosen_member_json_url" value="<?=$json_url?>"/>
 </div>

--- a/themes/third_party/vmg_chosen_member/vmg_chosen_member.js
+++ b/themes/third_party/vmg_chosen_member/vmg_chosen_member.js
@@ -10,7 +10,6 @@ $(document).ready(function(){
 		var vmgcm_max_selections = $('#vmg_chosen_member_' + unique_id + '_max_selections').val();
 		var vmgcm_placeholder_text = $('#vmg_chosen_member_' + unique_id + '_placeholder_text').val();
 		var vmgcm_json_url = $(this).find('.vmg_chosen_member_json_url').val() + '&field_id=' + $('#vmg_chosen_member_' + unique_id + '_field_id').val();
-		var vmgcm_auto_update_author = $('#vmg_chosen_member_' + unique_id + '_auto_update_author').val();
 		
 		$('#vmg_chosen_member_' + unique_id).chosen(vmgcm_json_url, {
 			max_selections: vmgcm_max_selections,
@@ -18,16 +17,6 @@ $(document).ready(function(){
 		});
 
 		$('#hold_field_' + $('#vmg_chosen_member_' + unique_id + '_field_id').val()).css('overflow', 'visible');
-		
-		if (vmgcm_auto_update_author) {
-			$('#vmg_chosen_member_' + unique_id).change(function(){
-				
-				if ($("#author").length > 0) { // check if author field exists on page (could be hidden)
-					$('#author').val($(this).val()); // update author dropdown value
-				}
-				
-			});
-		}
 		
 	});
     
@@ -43,12 +32,10 @@ $(document).ready(function(){
             $('#vmg_chosen_member_' + current_field.attr('rel') + '_field_id').attr('id', 'vmg_chosen_member_' + unique_id + '_field_id');
             $('#vmg_chosen_member_' + current_field.attr('rel') + '_max_selections').attr('id', 'vmg_chosen_member_' + unique_id + '_max_selections');
             $('#vmg_chosen_member_' + current_field.attr('rel') + '_placeholder_text').attr('id', 'vmg_chosen_member_' + unique_id + '_placeholder_text');
-			$('#vmg_chosen_member_' + current_field.attr('rel') + '_auto_update_author').attr('id', 'vmg_chosen_member_' + unique_id + '_auto_update_author');
 			
             var vmgcm_max_selections = $('#vmg_chosen_member_' + unique_id + '_max_selections').val();
             var vmgcm_placeholder_text = $('#vmg_chosen_member_' + unique_id + '_placeholder_text').val();
             var vmgcm_json_url = $(this).find('.vmg_chosen_member_json_url').val() + '&field_id=' + $('#vmg_chosen_member_' + unique_id + '_field_id').val();
-            var vmgcm_auto_update_author = $('#vmg_chosen_member_' + unique_id + '_auto_update_author').val();
             
             $('#vmg_chosen_member_' + unique_id).chosen(vmgcm_json_url, {
                 max_selections: vmgcm_max_selections,
@@ -56,18 +43,7 @@ $(document).ready(function(){
             });
 
             $('#hold_field_' + $('#vmg_chosen_member_' + unique_id + '_field_id').val()).css('overflow', 'visible');
-        
-            if (vmgcm_auto_update_author) {
-            	
-				$('#vmg_chosen_member_' + unique_id).live("change", function(){
-					
-					if ($("#author").length > 0) { // check if author field exists on page (could be hidden)
-						$('#author').val($(this).val()); // update author dropdown value
-					}
-					
-				});
-			}
-            
+   
         }
     });
 


### PR DESCRIPTION
I had a requirement for a site where I wanted a VMG Chosen Member field to automatically update the EE author dropdown. I modified your add-on to do this with a javascript change() listener.

Essentially, it means a VMG Chosen Member field can act as an author select dropdown replacement.

I've added a checkbox fieldtype setting so this functionality can be toggled on or off. For instance, if you're using it to select multiple members you probably don't want to use it to update the author dropdown.

Not sure if you'll find use for this in the add-on, but thought I may as well push a version across to you in case you want to use it or build on it.

Thanks,

Oskar
@oskarsmith
